### PR TITLE
fix: create home directory for docker user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p $HOME/.docker/cli-plugins/ \
  && chmod +x /usr/local/bin/* \
  && chown root:root /usr/local/bin/*
 
-RUN useradd -u 1000 -g docker -s /bin/bash docker
+RUN useradd -m -u 1000 -g docker -s /bin/bash docker
 USER docker
 
 VOLUME ["/var/lib/docker"]


### PR DESCRIPTION
the home directory for the docker user is missing, so some commands will fail. the -m option should fix this:

```
-m 
[...]
By default, if this option is not specified and CREATE_HOME is not enabled, no home directories are created.
```