### PR TITLE
feat: make docker + docker-compose bash scripts compatible to be called within wsl

### DIFF
--- a/msi/scripts/docker
+++ b/msi/scripts/docker
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Wrapper script for tunneling docker commands from windows into WSL
-wsl -d clf_dockerinwsl -- docker "$@"
+wsl.exe -d clf_dockerinwsl -- docker "$@"

--- a/msi/scripts/docker-compose
+++ b/msi/scripts/docker-compose
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Wrapper script for tunneling docker commands from windows into WSL
-wsl -d clf_dockerinwsl -- docker-compose "$@"
+wsl.exe -d clf_dockerinwsl -- docker-compose "$@"


### PR DESCRIPTION
Adding .exe within the bash scripts allows them to be called not only from within Git Bash but also any WSL distro.